### PR TITLE
Use toDense() to convert the sparse vector

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaVectorSlicerExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaVectorSlicerExample.java
@@ -50,7 +50,7 @@ public class JavaVectorSlicerExample {
     AttributeGroup group = new AttributeGroup("userFeatures", attrs);
 
     List<Row> data = Arrays.asList(
-      RowFactory.create(Vectors.sparse(3, new int[]{0, 1}, new double[]{-2.0, 2.3})),
+      RowFactory.create(Vectors.sparse(3, new int[]{0, 1}, new double[]{-2.0, 2.3}).toDense()),
       RowFactory.create(Vectors.dense(-2.0, 2.3, 0.0))
     );
 


### PR DESCRIPTION
Need use the method toDense() to convert the type after create a sparse vector.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
